### PR TITLE
fix(qchat): change default username to `Geotribu`

### DIFF
--- a/qfield-plugin-qchat/main.qml
+++ b/qfield-plugin-qchat/main.qml
@@ -19,7 +19,7 @@ Item {
     id: qchatSettings
     property string lastUrl: 'gischat.geotribu.net'//wss://gischat.geotribu.net/room/QGIS/ws'
     property string lastRoom: 'QGIS'
-    property string lastUserName: 'nirvn'
+    property string lastUserName: 'Geotribu'
   }
 
   Component.onCompleted: {


### PR DESCRIPTION
Sorry @nirvn :eyes: , we could experience this in Avignon. A follow-up PR could be to set no default username at all, and force the user to input a username in order to move forward, don't if that would be possible :thinking: 