### PR TITLE
ci(release): add gh workflow to create release and publish zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: 🚀 Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  release:
+
+    name: 👷 GitHub Release
+    runs-on: ubuntu-latest
+
+    if: github.ref_type == 'tag'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Zip the QField plugin
+        run: |
+          cd qfield-plugin-qchat
+          zip -r "../qfchat-${GITHUB_REF#refs/tags/}.zip" ./*
+          zip -r "../qfchat-latest.zip" ./*
+
+      - name: Create GitHub Release with assets
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            qfchat-${GITHUB_REF#refs/tags/}.zip
+            qfchat-latest.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,10 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
+        - id: check-added-large-files
+        - id: check-case-conflict
+        - id: check-yaml
+        - id: detect-private-key
+        - id: end-of-file-fixer
+        - id: no-commit-to-branch
+        - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can follow [the QField documentation](https://docs.qfield.org/how-to/plugins
 The URL to install the `QChat` plugin is:
 
 ```
-https://github.com/geotribu/qchat-qfield-plugin/releases/latest/download/qfield-plugin-qchat.zip
+https://github.com/geotribu/qchat-qfield-plugin/releases/latest/download/qfchat-latest.zip
 ```
 
 ----


### PR DESCRIPTION
Would be nice to do this automatically, so that the QChat backend can propose an endpoint to download easily the latest zip of the plugin.