### PR TITLE
ui: use anchors to dock the minimized bar to the bottom

### DIFF
--- a/qfield-plugin-qchat/main.qml
+++ b/qfield-plugin-qchat/main.qml
@@ -578,12 +578,20 @@ Item {
         border.width: 1
         border.color: Theme.mainColor
 
+        function getBottomMargin() {
+            const featureForm = iface.findItemByObjectName("featureForm");
+            if (!featureForm) {
+                return 10;
+            }
+            return parent.height - featureForm.y + 10;
+        }
+
         states: State {
             name: "shown"
             when: plugin.qchatMinimized && !connectionDialog.visible && !qchatMainDialog.visible
             PropertyChanges {
                 target: minimizedBar
-                anchors.bottomMargin: 10
+                anchors.bottomMargin: getBottomMargin()
             }
         }
 

--- a/qfield-plugin-qchat/main.qml
+++ b/qfield-plugin-qchat/main.qml
@@ -584,7 +584,7 @@ Item {
             if (!featureForm) {
                 return osNavBarHeight + 10;
             }
-            return parent.height - featureForm.y + osNavBarHeight + 10;
+            return parent.height - featureForm.y + 10;
         }
 
         states: State {

--- a/qfield-plugin-qchat/main.qml
+++ b/qfield-plugin-qchat/main.qml
@@ -563,10 +563,15 @@ Item {
         id: minimizedBar
         parent: mainWindow.contentItem
 
-        x: 136
-        y: mainWindow.height + 8
-        width: mainWindow.width - 136 - 64
-        height: 44
+        visible: plugin.qchatMinimized && !connectionDialog.visible && !qchatMainDialog.visible
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: 88 + 10 // a bit of place for the scale widget
+        anchors.rightMargin: 48 + 10 // 48 = tool button size (location button) + 5 x 2 spacing
+        anchors.bottomMargin: -height // start below the canvas to make the transition smoother
+        height: 48 // tool button height
         z: 1
         radius: 8
         color: Theme.mainBackgroundColor
@@ -578,7 +583,7 @@ Item {
             when: plugin.qchatMinimized && !connectionDialog.visible && !qchatMainDialog.visible
             PropertyChanges {
                 target: minimizedBar
-                y: plugin.mapCanvas.y + plugin.mapCanvas.height - minimizedBar.height - 8
+                anchors.bottomMargin: 10
             }
         }
 
@@ -587,7 +592,7 @@ Item {
                 from: ""
                 to: "shown"
                 NumberAnimation {
-                    property: "y"
+                    property: "anchors.bottomMargin"
                     duration: 360
                     easing.type: Easing.OutBack
                     easing.overshoot: 1.1
@@ -597,7 +602,7 @@ Item {
                 from: "shown"
                 to: ""
                 NumberAnimation {
-                    property: "y"
+                    property: "anchors.bottomMargin"
                     duration: 200
                     easing.type: Easing.InBack
                     easing.overshoot: 0.8

--- a/qfield-plugin-qchat/main.qml
+++ b/qfield-plugin-qchat/main.qml
@@ -581,7 +581,7 @@ Item {
         function getBottomMargin() {
             const osNavBarHeight = mainWindow.sceneBottomMargin;
             const featureForm = iface.findItemByObjectName("featureForm");
-            if (!featureForm) {
+            if (!featureForm.visible) {
                 return osNavBarHeight + 10;
             }
             return parent.height - featureForm.y + 10;

--- a/qfield-plugin-qchat/main.qml
+++ b/qfield-plugin-qchat/main.qml
@@ -579,11 +579,12 @@ Item {
         border.color: Theme.mainColor
 
         function getBottomMargin() {
+            const osNavBarHeight = mainWindow.sceneBottomMargin;
             const featureForm = iface.findItemByObjectName("featureForm");
             if (!featureForm) {
-                return 10;
+                return osNavBarHeight + 10;
             }
-            return parent.height - featureForm.y + 10;
+            return parent.height - featureForm.y + osNavBarHeight + 10;
         }
 
         states: State {


### PR DESCRIPTION
Follow-up of #17 

Closes #18 

Using `anchor` to the parent and display the minimized bar on top of the `featureForm` :

https://github.com/user-attachments/assets/89086239-8ea2-4c6f-b8e6-d19b004dde2a
