### PR TITLE
ci: add a workflow that zips, generates a QR code and comments on PRs

### DIFF
--- a/.github/scripts/delete-bot-comment.js
+++ b/.github/scripts/delete-bot-comment.js
@@ -1,0 +1,11 @@
+module.exports = async ({ github, context }) => {
+  const commentId = parseInt(process.env.COMMENT_ID, 10);
+  if (commentId) {
+    await github.rest.issues.deleteComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: commentId,
+    });
+    console.log(`Deleted comment #${commentId}`);
+  }
+};

--- a/.github/scripts/delete-pr-prereleases.js
+++ b/.github/scripts/delete-pr-prereleases.js
@@ -1,0 +1,23 @@
+module.exports = async ({ github, context }) => {
+  const prefix = process.env.TAG_PREFIX;
+  const { data: releases } = await github.rest.repos.listReleases({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    per_page: 100,
+  });
+  const toDelete = releases.filter(r => r.prerelease && r.tag_name.startsWith(prefix));
+  console.log(`${toDelete.length} pre-release(s) to delete with prefix "${prefix}"`);
+  for (const release of toDelete) {
+    await github.rest.repos.deleteRelease({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      release_id: release.id,
+    });
+    await github.rest.git.deleteRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: `tags/${release.tag_name}`,
+    });
+    console.log(`Deleted: ${release.tag_name}`);
+  }
+};

--- a/.github/scripts/generate_qr_code.py
+++ b/.github/scripts/generate_qr_code.py
@@ -1,0 +1,7 @@
+import os
+import qrcode
+
+url = os.environ["FILE_URL"]
+img = qrcode.make(url)
+img.save("qrcode.png")
+print(f"QR code generated for: {url}")

--- a/.github/workflows/pr_qrcode.yml
+++ b/.github/workflows/pr_qrcode.yml
@@ -95,7 +95,7 @@ jobs:
 
             ---
 
-            ### 📱 QR Code — Scan to download
+            ### 📱 QR Code — Flash in QField to test
 
             <img src="https://github.com/${{ github.repository }}/releases/download/${{ steps.config.outputs.tag_name }}/qrcode.png" alt="QR Code" width="360"/>
 

--- a/.github/workflows/pr_qrcode.yml
+++ b/.github/workflows/pr_qrcode.yml
@@ -1,0 +1,138 @@
+name: ⛶ Zip & QR Code
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+
+jobs:
+  zip-and-qr:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Configure variables used later in the workflow
+        id: config
+        run: |
+          DIRECTORY="qfield-plugin-qchat"
+          ZIP_NAME="qfchat-pr-${{ github.event.pull_request.number }}-${{ github.sha }}.zip"
+          TAG_NAME="pr-${{ github.event.pull_request.number }}-${{ github.sha }}"
+          TAG_PREFIX="pr-${{ github.event.pull_request.number }}-"
+          echo "directory=$DIRECTORY" >> $GITHUB_OUTPUT
+          echo "zip_name=$ZIP_NAME" >> $GITHUB_OUTPUT
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "tag_prefix=$TAG_PREFIX" >> $GITHUB_OUTPUT
+          echo "sha_short=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+
+      - name: Delete previous pre-releases for this PR
+        uses: actions/github-script@v9
+        env:
+          TAG_PREFIX: ${{ steps.config.outputs.tag_prefix }}
+        with:
+          script: |
+            const script = require('./.github/scripts/delete-pr-prereleases.js')
+            await script({ github, context })
+
+      - name: Zip the QField plugin
+        run: |
+          cd ${{ steps.config.outputs.directory }}
+          zip -r "../${{ steps.config.outputs.zip_name }}" ./*
+
+      - name: Create pre-release with the ZIP
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.config.outputs.tag_name }}
+          name: "PR #${{ github.event.pull_request.number }} - qfield-plugin-qchat"
+          prerelease: true
+          files: |
+            ${{ steps.config.outputs.zip_name }}
+            qrcode.png
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate QR code
+        run: |
+          pip install qrcode[pil] --quiet
+          python3 .github/scripts/generate_qr_code.py
+        env:
+          FILE_URL: https://github.com/${{ github.repository }}/releases/download/${{ steps.config.outputs.tag_name }}/${{ steps.config.outputs.zip_name }}
+
+      - name: Find existing bot comment
+        uses: peter-evans/find-comment@v4
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: ZIP artefact generated
+
+      - name: Create or update comment on the Pull Request
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            ## 📦 ZIP artefact generated
+
+            | Info | Value |
+            |------|-------|
+            | 📁 Directory | `${{ steps.config.outputs.directory }}` |
+            | 🗜️ File | `${{ steps.config.outputs.zip_name }}` |
+            | 🔑 Commit | `${{ steps.config.outputs.sha_short }}` |
+
+            ### 📥 Download
+            👉 [Download the ZIP directly](https://github.com/${{ github.repository }}/releases/download/${{ steps.config.outputs.tag_name }}/${{ steps.config.outputs.zip_name }})
+
+            ---
+
+            ### 📱 QR Code — Scan to download
+
+            <img src="https://github.com/${{ github.repository }}/releases/download/${{ steps.config.outputs.tag_name }}/qrcode.png" alt="QR Code" width="360"/>
+
+  cleanup:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Delete all pre-releases for this PR
+        uses: actions/github-script@v9
+        env:
+          TAG_PREFIX: pr-${{ github.event.pull_request.number }}-
+        with:
+          script: |
+            const script = require('./.github/scripts/delete-pr-prereleases.js')
+            await script({ github, context })
+
+      - name: Find bot comment
+        uses: peter-evans/find-comment@v4
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: ZIP artefact generated
+
+      - name: Delete bot comment
+        if: steps.find-comment.outputs.comment-id != ''
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ steps.find-comment.outputs.comment-id }}
+        with:
+          script: |
+            const script = require('./.github/scripts/delete-bot-comment.js')
+            await script({ github, context })

--- a/.github/workflows/pr_qrcode.yml
+++ b/.github/workflows/pr_qrcode.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   zip-and-qr:
+    name: 📱 Generate ZIP and QR code for PR
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     permissions:
@@ -100,6 +101,7 @@ jobs:
             <img src="https://github.com/${{ github.repository }}/releases/download/${{ steps.config.outputs.tag_name }}/qrcode.png" alt="QR Code" width="360"/>
 
   cleanup:
+    name: 🧹 Cleanup on PR close
     runs-on: ubuntu-latest
     if: github.event.action == 'closed'
     permissions:

--- a/.github/workflows/pr_qrcode.yml
+++ b/.github/workflows/pr_qrcode.yml
@@ -49,7 +49,14 @@ jobs:
           cd ${{ steps.config.outputs.directory }}
           zip -r "../${{ steps.config.outputs.zip_name }}" ./*
 
-      - name: Create pre-release with the ZIP
+      - name: Generate QR code
+        run: |
+          pip install qrcode[pil] --quiet
+          python3 .github/scripts/generate_qr_code.py
+        env:
+          FILE_URL: https://github.com/${{ github.repository }}/releases/download/${{ steps.config.outputs.tag_name }}/${{ steps.config.outputs.zip_name }}
+
+      - name: Create pre-release with the ZIP and the QR code
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.config.outputs.tag_name }}
@@ -59,13 +66,6 @@ jobs:
             ${{ steps.config.outputs.zip_name }}
             qrcode.png
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate QR code
-        run: |
-          pip install qrcode[pil] --quiet
-          python3 .github/scripts/generate_qr_code.py
-        env:
-          FILE_URL: https://github.com/${{ github.repository }}/releases/download/${{ steps.config.outputs.tag_name }}/${{ steps.config.outputs.zip_name }}
 
       - name: Find existing bot comment
         uses: peter-evans/find-comment@v4


### PR DESCRIPTION
The idea is to get a GitHub bot commenting on PRs with a flashable QR code for testing on QField devices.

At the moment, since GitHub artifacts are not publicly available and need the user to be logged in order to see them, the workflow is - _unfortunately_ - creating GitHub pre-releases, tagged with the PR number and commit sha.  
TBH it does not feel optimal, though IDK if there might be another way without using 3rd party file-sharing services. So let's make sure that the pre-releases are deleted when a PR gets closed / merged.

_Note: using some LLMs to understand GitHub API & scripts._