### PR TITLE
feat: display message's send time in the QChat dialog

### DIFF
--- a/qfield-plugin-qchat/main.qml
+++ b/qfield-plugin-qchat/main.qml
@@ -385,15 +385,17 @@ Item {
                                         color: Theme.secondaryTextColor
                                         wrapMode: Text.WordWrap
                                         text: {
+                                            const messageTime = new Date(historyData.timestamp).toLocaleTimeString({
+                                                hour: "2-digit",
+                                                minute: "2-digit",
+                                                second: "2-digit"
+                                            });
                                             switch (historyType) {
                                             case plugin.qchat_message_type_text:
-                                                return "<i>" + qsTr("%1:").arg(historyData.author) + "</i>";
                                             case plugin.qchat_message_type_image:
-                                                return "<i>" + qsTr("%1:").arg(historyData.author) + "</i>";
                                             case plugin.qchat_message_type_bbox:
-                                                return "<i>" + qsTr("%1:").arg(historyData.author) + "</i>";
                                             case plugin.qchat_message_type_position:
-                                                return "<i>" + qsTr("%1:").arg(historyData.author) + "</i>";
+                                                return "<i>" + qsTr("%1").arg(historyData.author) + "</i> (" + messageTime + "):";
                                             }
                                             return "";
                                         }


### PR DESCRIPTION
Displaying in the QChat widget when the message was sent:

| Before | After |
| --- | --- |
| <img width="483" height="655" alt="image" src="https://github.com/user-attachments/assets/d0afd22a-4e57-4ebc-b0fb-36df2a8cb53a" /> | <img width="490" height="657" alt="image" src="https://github.com/user-attachments/assets/ddfd3da2-db8e-4c7e-892a-b92bcf6e984a" />|