### PR TITLE
ci: remove matrix notification step on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,3 @@ jobs:
             qfchat-latest.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Send notification on matrix
-        id: matrix-notification
-        uses: fadenb/matrix-chat-message@v0.0.6
-        with:
-          homeserver: ${{ secrets.PUBLISH_MATRIX_HOMESERVER }}
-          token: ${{ secrets.PUBLISH_MATRIX_TOKEN }}
-          channel: ${{ secrets.PUBLISH_MATRIX_CHANNEL }}
-          message: |
-            💬 New QChat QField plugin version: ${{ github.ref_name }} !\
-            -> https://github.com/geotribu/qchat-qfield-plugin/releases


### PR DESCRIPTION
Since it's kind of broken and always needs manual token refresh...